### PR TITLE
update README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pod "ESPullToRefresh"
 ### Carthage
 
 ```ruby
-github "eggswift/ESPullToRefresh"
+github "eggswift/pull-to-refresh"
 ```
 
 ### Manually


### PR DESCRIPTION
Updating the README Carthage section, because the old given command is not working, generating Github errors.