### PR TITLE
增加ESRefreshExampleType: day

### DIFF
--- a/ESPullToRefreshExample/ESPullToRefreshExample/Custom/ESRefreshTableViewController.swift
+++ b/ESPullToRefreshExample/ESPullToRefreshExample/Custom/ESRefreshTableViewController.swift
@@ -50,6 +50,9 @@ public class ESRefreshTableViewController: UITableViewController {
         case .wechat:
             header = WCRefreshHeaderAnimator.init(frame: CGRect.zero)
             footer = ESRefreshFooterAnimator.init(frame: CGRect.zero)
+        case .day:
+            header = ESRefreshDayHeaderAnimator.init(frame: CGRect.zero)
+            footer = ESRefreshFooterAnimator.init(frame: CGRect.zero)
         default:
             header = ESRefreshHeaderAnimator.init(frame: CGRect.zero)
             footer = ESRefreshFooterAnimator.init(frame: CGRect.zero)

--- a/ESPullToRefreshExample/ESPullToRefreshExample/ViewController.swift
+++ b/ESPullToRefreshExample/ESPullToRefreshExample/ViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 public enum ESRefreshExampleType {
-    case defaulttype, meituan, wechat
+    case defaulttype, meituan, wechat, day
 }
 
 public enum ESRefreshExampleListType {
@@ -66,6 +66,9 @@ public class ViewController: UIViewController, UITableViewDataSource, UITableVie
             vc = TextViewController.init()
         case 4:
             vc = ESRefreshTableViewController.init(style: .plain)
+            if let vc = vc as? ESRefreshTableViewController {
+                vc.type = .day
+            }
         case 5:
             vc = CollectionViewController()
         default:


### PR DESCRIPTION
```swift
public enum ESRefreshExampleType {
    case defaulttype, meituan, wechat, day
}

public class ViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
    ...
    public func select(indexPath: IndexPath) {
        ...
        case 4:
            vc = ESRefreshTableViewController.init(style: .plain)
                if let vc = vc as? ESRefreshTableViewController {
                    vc.type = .day
                }
        ...
    }
    ...
}

public class ESRefreshTableViewController: UITableViewController {
    ...
    public override func viewDidLoad() {
        switch type {
        ...
        case .day:
            header = ESRefreshDayHeaderAnimator.init(frame: CGRect.zero)
            footer = ESRefreshFooterAnimator.init(frame: CGRect.zero)
        }
        ...
    }
    ...
}
```

