### PR TITLE
Use Bundle init(for:) for loading image

### DIFF
--- a/Sources/Animator/ESRefreshHeaderAnimator.swift
+++ b/Sources/Animator/ESRefreshHeaderAnimator.swift
@@ -41,7 +41,7 @@ open class ESRefreshHeaderAnimator: UIView, ESRefreshProtocol, ESRefreshAnimator
     fileprivate let imageView: UIImageView = {
         let imageView = UIImageView.init()
         if #available(iOS 8, *) {
-            imageView.image = UIImage(named: "icon_pull_to_refresh_arrow", in: Bundle(identifier: "com.eggswift.ESPullToRefresh"), compatibleWith: nil)
+            imageView.image = UIImage(named: "icon_pull_to_refresh_arrow", in: Bundle(for: ESRefreshHeaderAnimator.self), compatibleWith: nil)
         } else {
             imageView.image = UIImage(named: "icon_pull_to_refresh_arrow")
         }


### PR DESCRIPTION
"icon_pull_to_refresh_arrow.png" wasn't loaded when installed via CocoaPods with `use_frameworks!` option on.

I looked in to the code, and the UIImage() in `ESRefreshHeaderAnimator` was returning nil.

```
// ESRefreshHeaderAnimator
UIImage(named: "icon_pull_to_refresh_arrow", in: Bundle(identifier: "com.eggswift.ESPullToRefresh"), compatibleWith: nil)
```
https://github.com/eggswift/pull-to-refresh/blob/master/Sources/Animator/ESRefreshHeaderAnimator.swift#L44

It looks like the bundle identifier for the pod is "org.cocoapods.ESPullToRefresh".

<img width="473" alt="screen shot 2016-12-23 at 11 53 30" src="https://cloud.githubusercontent.com/assets/650265/21446211/93824272-c906-11e6-9233-4c4ae07075c4.png">

This PR uses the `Bundle(for:)` instead of `Bundle(identifier:)` to load the resource.