### PR TITLE
added @discardableResult

### DIFF
--- a/ESPullToRefreshExample/ESPullToRefreshExample/Custom/CollectionView/CollectionViewController.swift
+++ b/ESPullToRefreshExample/ESPullToRefreshExample/Custom/CollectionView/CollectionViewController.swift
@@ -50,11 +50,11 @@ class CollectionViewController: UIViewController {
         self.view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: vflDict[1] as String, options: [], metrics: nil, views: viewsDict))
         
         //  add pull to refresh
-        _ = self.collectionView.es_addPullToRefresh {
+        self.collectionView.es_addPullToRefresh {
             self.loadData()
         }
         self.collectionView.es_startPullToRefresh()
-        _ = self.collectionView.es_addInfiniteScrolling {
+        self.collectionView.es_addInfiniteScrolling {
             self.delay(time: 2) {
                 for item in 21...40 {
                     self.list.append(String(item))

--- a/ESPullToRefreshExample/ESPullToRefreshExample/Custom/ESRefreshTableViewController.swift
+++ b/ESPullToRefreshExample/ESPullToRefreshExample/Custom/ESRefreshTableViewController.swift
@@ -56,10 +56,10 @@ public class ESRefreshTableViewController: UITableViewController {
             break
         }
         
-        let _ = self.tableView.es_addPullToRefresh(animator: header) { [weak self] in
+        self.tableView.es_addPullToRefresh(animator: header) { [weak self] in
             self?.refresh()
         }
-        let _ = self.tableView.es_addInfiniteScrolling(animator: footer) { [weak self] in
+        self.tableView.es_addInfiniteScrolling(animator: footer) { [weak self] in
             self?.loadMore()
         }
         self.tableView.refreshIdentifier = String.init(describing: type)

--- a/ESPullToRefreshExample/ESPullToRefreshExample/Custom/TextView/TextViewController.swift
+++ b/ESPullToRefreshExample/ESPullToRefreshExample/Custom/TextView/TextViewController.swift
@@ -30,7 +30,7 @@ class TextViewController: UIViewController {
         textView.textContainerInset = UIEdgeInsets.init(top: 12, left: 8, bottom: 12, right: 8)
         self.view.addSubview(textView)
         
-        let _ = textView.es_addPullToRefresh {
+        textView.es_addPullToRefresh {
             [weak self] in
             guard let weakSelf = self else {
                 return
@@ -46,7 +46,7 @@ class TextViewController: UIViewController {
             }
         }
         
-        let _ = textView.es_addInfiniteScrolling {
+        textView.es_addInfiniteScrolling {
             [weak self] in
             guard let weakSelf = self else {
                 return

--- a/ESPullToRefreshExample/ESPullToRefreshExample/WebViewController.swift
+++ b/ESPullToRefreshExample/ESPullToRefreshExample/WebViewController.swift
@@ -31,7 +31,7 @@ class WebViewController: UIViewController, UIWebViewDelegate {
         self.title = "egg swift"
         let request = NSURLRequest.init(url: NSURL(string: url)! as URL)
         
-        let _ = self.webView.scrollView.es_addPullToRefresh {
+        self.webView.scrollView.es_addPullToRefresh {
             [weak self] in
             self!.webView.loadRequest(request as URLRequest)
         }

--- a/Sources/ESPullToRefresh.swift
+++ b/Sources/ESPullToRefresh.swift
@@ -44,6 +44,7 @@ public extension UIScrollView {
     }
     
     /// Add pull-to-refresh
+    @discardableResult
     public func es_addPullToRefresh(handler: @escaping ESRefreshHandler) -> ESRefreshHeaderView {
         es_removeRefreshHeader()
         let header = ESRefreshHeaderView(frame: CGRect.zero, handler: handler)
@@ -54,6 +55,7 @@ public extension UIScrollView {
         return header
     }
     
+    @discardableResult
     public func es_addPullToRefresh(animator: ESRefreshProtocol & ESRefreshAnimatorProtocol, handler: @escaping ESRefreshHandler) -> ESRefreshHeaderView {
         es_removeRefreshHeader()
         let header = ESRefreshHeaderView(frame: CGRect.zero, handler: handler, animator: animator)
@@ -65,6 +67,7 @@ public extension UIScrollView {
     }
     
     /// Add infinite-scrolling
+    @discardableResult
     public func es_addInfiniteScrolling(handler: @escaping ESRefreshHandler) -> ESRefreshFooterView {
         es_removeRefreshFooter()
         let footer = ESRefreshFooterView(frame: CGRect.zero, handler: handler)
@@ -75,6 +78,7 @@ public extension UIScrollView {
         return footer
     }
 
+    @discardableResult
     public func es_addInfiniteScrolling(animator: ESRefreshProtocol & ESRefreshAnimatorProtocol, handler: @escaping ESRefreshHandler) -> ESRefreshFooterView {
         es_removeRefreshFooter()
         let footer = ESRefreshFooterView(frame: CGRect.zero, handler: handler, animator: animator)


### PR DESCRIPTION
added `@discardableResult` annotation to

`es_addPullToRefresh(handler:)`
`es_addPullToRefresh(animator:handler:)`
`es_addInfiniteScrolling(handler:)`
`es_addInfiniteScrolling(animator:handler:)`

for suppress the warning.

FYI [swift-evolution/0047-nonvoid-warn.md](https://github.com/apple/swift-evolution/blob/master/proposals/0047-nonvoid-warn.md#detail-design)