### PR TITLE
Make compatible With Swift4

### DIFF
--- a/Sources/ESRefreshComponent.swift
+++ b/Sources/ESRefreshComponent.swift
@@ -114,7 +114,25 @@ open class ESRefreshComponent: UIView {
             }
         }
     }
+   
+    public func start() {
+        
+    }
     
+    public func stop() {
+        _isRefreshing = false
+        _isAutoRefreshing = false
+    }
+    
+    //  ScrollView contentSize change action
+    public func sizeChangeAction(object: AnyObject?, change: [NSKeyValueChangeKey : Any]?) {
+        
+    }
+    
+    //  ScrollView offset change action
+    public func offsetChangeAction(object: AnyObject?, change: [NSKeyValueChangeKey : Any]?) {
+        
+    }
 }
 
 extension ESRefreshComponent /* KVO methods */ {
@@ -186,26 +204,6 @@ public extension ESRefreshComponent /* Action */ {
         }
         
         self.stop()
-    }
-
-    public func start() {
-        
-    }
-    
-    public func stop() {
-        _isRefreshing = false
-        _isAutoRefreshing = false
-    }
-    
-    //  ScrollView contentSize change action
-    public func sizeChangeAction(object: AnyObject?, change: [NSKeyValueChangeKey : Any]?) {
-        
-    }
-    
-    //  ScrollView offset change action
-    public func offsetChangeAction(object: AnyObject?, change: [NSKeyValueChangeKey : Any]?) {
-        
-    }
-    
+    }    
 }
 


### PR DESCRIPTION
 Move  `start/stop/sizeChangeAction/offsetChangeAction` function out of extension, because extensions cannot override in Swift 4

Please see more [declarations-in-extensions-cannot-override-yet-error-in-swift-4]( https://stackoverflow.com/questions/44616409/declarations-in-extensions-cannot-override-yet-error-in-swift-4)