### PR TITLE
fix for XCode 10.3

### DIFF
--- a/Sources/Animator/ESRefreshFooterAnimator.swift
+++ b/Sources/Animator/ESRefreshFooterAnimator.swift
@@ -47,7 +47,7 @@ open class ESRefreshFooterAnimator: UIView, ESRefreshProtocol, ESRefreshAnimator
     }()
     
     fileprivate let indicatorView: UIActivityIndicatorView = {
-        let indicatorView = UIActivityIndicatorView.init(style: .gray)
+        let indicatorView = UIActivityIndicatorView.init(activityIndicatorStyle: .gray)
         indicatorView.isHidden = true
         return indicatorView
     }()

--- a/Sources/Animator/ESRefreshHeaderAnimator.swift
+++ b/Sources/Animator/ESRefreshHeaderAnimator.swift
@@ -66,7 +66,7 @@ open class ESRefreshHeaderAnimator: UIView, ESRefreshProtocol, ESRefreshAnimator
     }()
     
     fileprivate let indicatorView: UIActivityIndicatorView = {
-        let indicatorView = UIActivityIndicatorView.init(style: .gray)
+        let indicatorView = UIActivityIndicatorView.init(activityIndicatorStyle: .gray)
         indicatorView.isHidden = true
         return indicatorView
     }()


### PR DESCRIPTION
Fix for

```
/Users/vsts/agent/2.155.1/work/1/s/Pods/ESPullToRefresh/Sources/Animator/ESRefreshFooterAnimator.swift:50:53: error: 'init(style:)' has been renamed to 'init(activityIndicatorStyle:)'
        let indicatorView = UIActivityIndicatorView.init(style: .gray)
                                                    ^    ~~~~~
                                                         activityIndicatorStyle
UIKit.UIActivityIndicatorView:6:12: note: 'init(style:)' was introduced in Swift 4.2
    public init(style: UIActivityIndicatorViewStyle)
```