### PR TITLE
删除headerview结束刷新动画前对scrollView属性的修改代码

### DIFF
--- a/Sources/ESPullToRefresh.swift
+++ b/Sources/ESPullToRefresh.swift
@@ -321,8 +321,6 @@ open class ESRefreshHeaderView: ESRefreshComponent {
         self.animator.refreshAnimationEnd(view: self)
         
         // Back state
-        scrollView.contentInset.top = self.scrollViewInsets.top
-        scrollView.contentOffset.y =  self.scrollViewInsets.top + self.previousOffset
         UIView.animate(withDuration: 0.2, delay: 0, options: .curveLinear, animations: {
             scrollView.contentOffset.y = -self.scrollViewInsets.top
             }, completion: { (finished) in


### PR DESCRIPTION
修复animator的insets不为UIEdgeInsets.zero时，headerview结束刷新动画显示异常的问题