### PR TITLE
解决下拉刷新出现抖动的问题

### DIFF
--- a/Sources/ESPullToRefresh.swift
+++ b/Sources/ESPullToRefresh.swift
@@ -330,7 +330,7 @@ open class ESRefreshHeaderView: ESRefreshComponent {
         
         // Back state
         scrollView.contentInset.top = self.scrollViewInsets.top
-        if previousOffset < 0 {
+        if (previousOffset + scrollView.contentInset.top) < 0 {
             scrollView.contentOffset.y =  self.previousOffset
             UIView.animate(withDuration: 0.2, delay: 0, options: .curveLinear, animations: {
                 scrollView.contentOffset.y = -self.scrollViewInsets.top
@@ -339,7 +339,7 @@ open class ESRefreshHeaderView: ESRefreshComponent {
             })
         } else {
             execute()
-        }   
+        }
     }
     
 }


### PR DESCRIPTION
原本的bug:
当下拉刷新时，将UIScrollView滚动到 contentOffset.y > 0
结束刷新时有个抖动的动画

此次提交已经解决这个问题