### PR TITLE
解决下拉刷新出现抖动的问题

### DIFF
--- a/Eddid-ESPullToRefresh.podspec
+++ b/Eddid-ESPullToRefresh.podspec
@@ -1,16 +1,16 @@
 
 Pod::Spec.new do |s|
-    s.name              = 'ESPullToRefresh'
-    s.version           = '2.9.2'
+    s.name              = 'Eddid-ESPullToRefresh'
+    s.version           = '2.9.2.1'
     s.summary           = 'An easy way to use pull-to-refresh and loading-more'
     s.description       = 'An easiest way to give pull-to-refresh and loading-more to any UIScrollView. Using swift!'
-    s.homepage          = 'https://github.com/eggswift/pull-to-refresh'
+    s.homepage          = 'https://github.com/chenfanfang/pull-to-refresh'
 
     s.license           = { :type => 'MIT', :file => 'LICENSE' }
     s.authors           = { 'lihao' => 'lihao_ios@hotmail.com'}
-    s.social_media_url  = 'https://github.com/eggswift'
+    s.social_media_url  = 'https://github.com/chenfanfang'
     s.platform          = :ios, '8.0'
-    s.source            = {:git => 'https://github.com/eggswift/pull-to-refresh.git', :tag => s.version}
+    s.source            = {:git => 'https://github.com/chenfanfang/pull-to-refresh.git', :tag => s.version}
     s.source_files      = ['Sources/**/*.{swift}']
     s.resource_bundles  = { 'ESPullToRefresh' => 'Sources/Animator/*.png' }
     s.requires_arc      = true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 > Fork from https://github.com/eggswift/pull-to-refresh.
+> 
 > fix: 当下拉刷新时，将UIScrollView滚动到 contentOffset.y > 0 结束刷新时有个抖动的bug
 
 ![logo](logo.png)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-> Fork from https://github.com/eggswift/pull-to-refresh.
-> 
-> fix: 当下拉刷新时，将UIScrollView滚动到 contentOffset.y > 0 结束刷新时有个抖动的bug
+```
+Fork from https://github.com/eggswift/pull-to-refresh.
+fix: 当下拉刷新时，将UIScrollView滚动到 contentOffset.y > 0 结束刷新时有个抖动的bug
+```
 
 ![logo](logo.png)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Fork from https://github.com/eggswift/pull-to-refresh. </r>
-fix: 当下拉刷新时，将UIScrollView滚动到 contentOffset.y > 0 结束刷新时有个抖动的bug
+> Fork from https://github.com/eggswift/pull-to-refresh.
+> fix: 当下拉刷新时，将UIScrollView滚动到 contentOffset.y > 0 结束刷新时有个抖动的bug
 
 ![logo](logo.png)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Fork from https://github.com/eggswift/pull-to-refresh. </r>
+fix: 当下拉刷新时，将UIScrollView滚动到 contentOffset.y > 0 结束刷新时有个抖动的bug
 
 ![logo](logo.png)
 
@@ -36,19 +38,19 @@ Download and run the ESPullToRefreshExample project in Xcode to see ESPullToRefr
 ### CocoaPods
 
 ``` ruby
-pod "ESPullToRefresh"
+pod "Eddid-ESPullToRefresh"
 ```
 
 ### Carthage
 
 ```ruby
-github "eggswift/pull-to-refresh"
+github "chenfanfang/pull-to-refresh"
 ```
 
 ### Manually
 
 ``` ruby
-git clone https://github.com/eggswift/pull-to-refresh.git
+git clone https://github.com/chenfanfang/pull-to-refresh.git
 open ESPullToRefresh
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,5 +1,5 @@
-Fork from https://github.com/eggswift/pull-to-refresh. </r>
-fix: 当下拉刷新时，将UIScrollView滚动到 contentOffset.y > 0 结束刷新时有个抖动的bug
+> Fork from https://github.com/eggswift/pull-to-refresh.
+> fix: 当下拉刷新时，将UIScrollView滚动到 contentOffset.y > 0 结束刷新时有个抖动的bug
 
 ![logo](logo.png)
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,4 +1,4 @@
-Fork from https://github.com/eggswift/pull-to-refresh
+Fork from https://github.com/eggswift/pull-to-refresh. </r>
 fix: 当下拉刷新时，将UIScrollView滚动到 contentOffset.y > 0 结束刷新时有个抖动的bug
 
 ![logo](logo.png)

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,3 +1,5 @@
+Fork from https://github.com/eggswift/pull-to-refresh
+fix: 当下拉刷新时，将UIScrollView滚动到 contentOffset.y > 0 结束刷新时有个抖动的bug
 
 ![logo](logo.png)
 
@@ -37,20 +39,20 @@
 ### CocoaPods
 
 ``` ruby
-pod "ESPullToRefresh"
+pod "Eddid-ESPullToRefresh"
 ```
 
 ### Carthage
 
 ```ruby
-github "eggswift/pull-to-refresh"
+github "chenfanfang/Eddid-ESPullToRefresh"
 ```
 
 ### 手动安装
 
 ``` ruby
-git clone https://github.com/eggswift/pull-to-refresh.git
-open ESPullToRefresh
+git clone https://github.com/chenfanfang/pull-to-refresh.git
+open Eddid-ESPullToRefresh
 ```
 
 ## 开始使用

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,5 +1,7 @@
-> Fork from https://github.com/eggswift/pull-to-refresh.
-> fix: 当下拉刷新时，将UIScrollView滚动到 contentOffset.y > 0 结束刷新时有个抖动的bug
+```
+Fork from https://github.com/eggswift/pull-to-refresh.
+fix: 当下拉刷新时，将UIScrollView滚动到 contentOffset.y > 0 结束刷新时有个抖动的bug
+```
 
 ![logo](logo.png)
 

--- a/Sources/ESPullToRefresh.swift
+++ b/Sources/ESPullToRefresh.swift
@@ -330,7 +330,7 @@ open class ESRefreshHeaderView: ESRefreshComponent {
         
         // Back state
         scrollView.contentInset.top = self.scrollViewInsets.top
-        if previousOffset < 0 {
+        if (previousOffset + scrollView.contentInset.top) < 0 {
             scrollView.contentOffset.y =  self.previousOffset
             UIView.animate(withDuration: 0.2, delay: 0, options: .curveLinear, animations: {
                 scrollView.contentOffset.y = -self.scrollViewInsets.top
@@ -339,7 +339,7 @@ open class ESRefreshHeaderView: ESRefreshComponent {
             })
         } else {
             execute()
-        }   
+        }
     }
     
 }


### PR DESCRIPTION
原本的bug:
当下拉刷新时，将UIScrollView滚动到 contentOffset.y > 0
结束刷新时有个抖动的动画

此次提交已经解决这个问题