### PR TITLE
fix 转成静态库crash

### DIFF
--- a/Sources/Animator/ESRefreshHeaderAnimator.swift
+++ b/Sources/Animator/ESRefreshHeaderAnimator.swift
@@ -47,7 +47,10 @@ open class ESRefreshHeaderAnimator: UIView, ESRefreshProtocol, ESRefreshAnimator
 
     fileprivate let imageView: UIImageView = {
         let imageView = UIImageView.init()
-        if /* Carthage */ let bundle = Bundle.init(identifier: "com.eggswift.ESPullToRefresh") {
+        let frameworkBundle = Bundle(for: ESRefreshAnimator.self)
+        if /* CocoaPods static */ let path = frameworkBundle.path(forResource: "ESPullToRefresh", ofType: "bundle"),let bundle = Bundle(path: path) {
+            imageView.image = UIImage(named: "icon_pull_to_refresh_arrow", in: bundle, compatibleWith: nil)
+        }else if /* Carthage */ let bundle = Bundle.init(identifier: "com.eggswift.ESPullToRefresh") {
             imageView.image = UIImage(named: "icon_pull_to_refresh_arrow", in: bundle, compatibleWith: nil)
         } else if /* CocoaPods */ let bundle = Bundle.init(identifier: "org.cocoapods.ESPullToRefresh") {
             imageView.image = UIImage(named: "ESPullToRefresh.bundle/icon_pull_to_refresh_arrow", in: bundle, compatibleWith: nil)


### PR DESCRIPTION
修复在CocoaPods 1.9+版本中链接方式改为静态崩溃.
Podfile文件
use_frameworks! :linkage => :static