### PR TITLE
Fixed observer race condition

### DIFF
--- a/Sources/ESRefreshComponent.swift
+++ b/Sources/ESRefreshComponent.swift
@@ -29,7 +29,9 @@ import UIKit
 public typealias ESRefreshHandler = (() -> ())
 
 open class ESRefreshComponent: UIView {
-    
+
+    private var observer: UIView?
+
     open weak var scrollView: UIScrollView?
     
     /// @param handler Refresh callback method
@@ -55,7 +57,6 @@ open class ESRefreshComponent: UIView {
     }
     
     /// @param tag observing
-    fileprivate var isObservingScrollView = false
     fileprivate var isIgnoreObserving = false
 
     public override init(frame: CGRect) {
@@ -171,18 +172,18 @@ extension ESRefreshComponent /* KVO methods */ {
     }
     
     fileprivate func addObserver(_ view: UIView?) {
-        if let scrollView = view as? UIScrollView, !isObservingScrollView {
+        if let scrollView = view as? UIScrollView, observer == nil {
+            observer = scrollView
             scrollView.addObserver(self, forKeyPath: ESRefreshComponent.offsetKeyPath, options: [.initial, .new], context: &ESRefreshComponent.context)
             scrollView.addObserver(self, forKeyPath: ESRefreshComponent.contentSizeKeyPath, options: [.initial, .new], context: &ESRefreshComponent.context)
-            isObservingScrollView = true
         }
     }
-    
+
     fileprivate func removeObserver() {
-        if let scrollView = superview as? UIScrollView, isObservingScrollView {
+        if let scrollView = observer {
             scrollView.removeObserver(self, forKeyPath: ESRefreshComponent.offsetKeyPath, context: &ESRefreshComponent.context)
             scrollView.removeObserver(self, forKeyPath: ESRefreshComponent.contentSizeKeyPath, context: &ESRefreshComponent.context)
-            isObservingScrollView = false
+            observer = nil
         }
     }
     


### PR DESCRIPTION
## Background
- In some edge cases we are observing issues with properly removing the observer because of reliance on `superview` and `isObservingScrollView` resulting in observed values getting emitted with no message handler. This ultimately results in a crash.

## Changes
- Instead of relying on `superview` to remove the observer we can set the `observer` ourselves when it gets created. This eliminates the need to check if its of type `UIScrollView` and also eliminates the need for `isObservingScrollView` since we can use the class-level `observer` to check if one is set before removing it