### PR TITLE
Added `indicatorColor` property to customize UIActivityIndicator color

### DIFF
--- a/ESPullToRefreshExample/ESPullToRefreshExample.xcodeproj/project.pbxproj
+++ b/ESPullToRefreshExample/ESPullToRefreshExample.xcodeproj/project.pbxproj
@@ -474,7 +474,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = ESPullToRefresh/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.eggswift.ESPullToRefresh;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -497,7 +497,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = ESPullToRefresh/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.eggswift.ESPullToRefresh;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -627,7 +627,7 @@
 				CURRENT_PROJECT_VERSION = 2.9.2;
 				DEVELOPMENT_TEAM = A367N9R36B;
 				INFOPLIST_FILE = ESPullToRefreshExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 2.9.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eggswift.ESPullToRefreshExample11;
@@ -645,7 +645,7 @@
 				CURRENT_PROJECT_VERSION = 2.9.2;
 				DEVELOPMENT_TEAM = A367N9R36B;
 				INFOPLIST_FILE = ESPullToRefreshExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 2.9.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eggswift.ESPullToRefreshExample11;

--- a/ESPullToRefreshExample/ESPullToRefreshExample/Custom/ESRefreshTableViewController.swift
+++ b/ESPullToRefreshExample/ESPullToRefreshExample/Custom/ESRefreshTableViewController.swift
@@ -56,12 +56,26 @@ public class ESRefreshTableViewController: UITableViewController {
             break
         }
         
-        self.tableView.es.addPullToRefresh(animator: header) { [weak self] in
-            self?.refresh()
+        if type == .defaultWithColor {
+            let header2 = ESRefreshHeaderAnimator.init(frame: CGRect.zero)
+            header2.indicatorColor = UIColor.red
+            self.tableView.es.addPullToRefresh(animator: header2) { [weak self] in
+                self?.refresh()
+            }
+            let footer2 = ESRefreshHeaderAnimator.init(frame: CGRect.zero)
+            footer2.indicatorColor = UIColor.green
+            self.tableView.es.addInfiniteScrolling(animator: footer2) { [weak self] in
+                self?.loadMore()
+            }
+        } else {
+            self.tableView.es.addPullToRefresh(animator: header) { [weak self] in
+                self?.refresh()
+            }
+            self.tableView.es.addInfiniteScrolling(animator: footer) { [weak self] in
+                self?.loadMore()
+            }
         }
-        self.tableView.es.addInfiniteScrolling(animator: footer) { [weak self] in
-            self?.loadMore()
-        }
+        
         self.tableView.refreshIdentifier = String.init(describing: type)
         self.tableView.expiredTimeInterval = 20.0
         

--- a/ESPullToRefreshExample/ESPullToRefreshExample/ViewController.swift
+++ b/ESPullToRefreshExample/ESPullToRefreshExample/ViewController.swift
@@ -15,6 +15,7 @@ public enum ESRefreshExampleType: String {
     case textView = "TextView"
     case day = "Day"
     case collectionView = "CollectionView"
+    case defaultWithColor = "Default With Color"
 }
 
 public enum ESRefreshExampleListType {
@@ -32,7 +33,8 @@ public class ViewController: UIViewController, UITableViewDataSource, UITableVie
         .wechat,
         .textView,
         .day,
-        .collectionView]
+        .collectionView,
+        .defaultWithColor]
     
     public override func viewDidLoad() {
         super.viewDidLoad()
@@ -72,6 +74,11 @@ public class ViewController: UIViewController, UITableViewDataSource, UITableVie
             vc = ESRefreshTableViewController.init(style: .plain)
         case .collectionView:
             vc = CollectionViewController()
+        case .defaultWithColor:
+            vc = ESRefreshTableViewController.init(style: .plain)
+            if let vc = vc as? ESRefreshTableViewController {
+                vc.type = .defaultWithColor
+            }
         }
         vc.title = element.rawValue
         self.navigationController?.pushViewController(vc, animated: true)

--- a/Sources/Animator/ESRefreshFooterAnimator.swift
+++ b/Sources/Animator/ESRefreshFooterAnimator.swift
@@ -52,6 +52,14 @@ open class ESRefreshFooterAnimator: UIView, ESRefreshProtocol, ESRefreshAnimator
         return indicatorView
     }()
     
+    open var indicatorColor: UIColor = .gray {
+        didSet {
+            if indicatorColor != oldValue {
+                indicatorView.color = indicatorColor
+            }
+        }
+    }
+    
     public override init(frame: CGRect) {
         super.init(frame: frame)
         titleLabel.text = loadingMoreDescription

--- a/Sources/Animator/ESRefreshHeaderAnimator.swift
+++ b/Sources/Animator/ESRefreshHeaderAnimator.swift
@@ -44,6 +44,14 @@ open class ESRefreshHeaderAnimator: UIView, ESRefreshProtocol, ESRefreshAnimator
     open var trigger: CGFloat = 60.0
     open var executeIncremental: CGFloat = 60.0
     open var state: ESRefreshViewState = .pullToRefresh
+    
+    open var indicatorColor: UIColor = .gray {
+        didSet {
+            if indicatorColor != oldValue {
+                indicatorView.color = indicatorColor
+            }
+        }
+    }
 
     fileprivate let imageView: UIImageView = {
         let imageView = UIImageView.init()


### PR DESCRIPTION
This PR adds the ability to customize the color of the loading indicators used in both the pull-to-refresh and infinite scrolling components of UITableView. A new property, indicatorColor, has been introduced to allow developers to set custom colors for the activity indicators in both the header and footer. This is particularly useful for ensuring that the loading indicators match the app's overall theme.

**Changes:**
Added the indicatorColor property to the pull-to-refresh and infinite scrolling animators.
Enabled color customization for the loading indicators in both the pull-to-refresh header and infinite scrolling footer.

**Why This Is Needed:**
This update enhances the flexibility of the pull-to-refresh and infinite scrolling components by allowing developers to match the loading indicator's color to the app's design, making it easier to integrate the indicators into both light and dark mode UIs.

**How to Use:**
To customize the color of the loading indicators, simply set the indicatorColor property on the header or footer animator as shown below:

```
// For pull-to-refresh header
let header = ESRefreshHeaderAnimator(frame: CGRect.zero)
header.indicatorColor = UIColor.red // Set the header indicator color
self.tableView.es.addPullToRefresh(animator: header) { [weak self] in
    self?.refresh()  // Trigger the refresh action
}

// For infinite scrolling footer
let footer = ESRefreshFooterAnimator(frame: CGRect.zero)
footer.indicatorColor = UIColor.green // Set the footer indicator color
self.tableView.es.addInfiniteScrolling(animator: footer) { [weak self] in
    self?.loadMore()  // Trigger the load more action
}
```